### PR TITLE
Use proper minus sign, to match plus sign

### DIFF
--- a/assets/goast.js
+++ b/assets/goast.js
@@ -97,7 +97,7 @@ func main() {\n\
         if (scope.collapsed) {
           return "+";
         } else {
-          return "-";
+          return "−";
         }
       } else {
         return " ";


### PR DESCRIPTION
This patch makes a visual improvement to the tree's collapse buttons, by changing the hyphen to a minus sign.

The ASCII hyphen (-) in many fonts is shorter and lower than the plus sign (+) so they do not match: +-+-+-+
The minus sign (−) at U+2212 should have the same width and alignment as plus, so they match up: +−+−+−+
